### PR TITLE
Fix gtagId => trackingId

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -11,7 +11,7 @@ exports.onRenderBody = (
   if (
     process.env.NODE_ENV !== 'production' ||
     !pluginOptions.cookihubId ||
-    !pluginOptions.gtagId
+    !pluginOptions.trackingId
   ) {
     return null;
   }


### PR DESCRIPTION
The plugin never initializes because it's looking for `gtagId` here, while everywhere else it uses `trackingId`.