### PR TITLE
Wrap variables in quotes when passing to gtag

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -67,13 +67,13 @@ exports.onRenderBody = (
         onInitialise: function(status) {
           if (this.hasConsented('analytics')) {
             window.GATSBY_PLUGIN_COOKIEHUB_DISABLED_ANALYTICS = false;
-            gtag('config', ${pluginOptions.trackingId});            
+            gtag('config', '${pluginOptions.trackingId}');
           }
         },
         onAllow: function(category) {
           if (category == 'analytics') {
             window.GATSBY_PLUGIN_COOKIEHUB_DISABLED_ANALYTICS = false;
-            gtag('config', ${pluginOptions.trackingId});
+            gtag('config', '${pluginOptions.trackingId}');
           }
         },
         onRevoke: function(category) {


### PR DESCRIPTION
Without wrapping in quotes, these strings are interpolated into (non-existent) variable references.

```
Uncaught ReferenceError: UA is not defined
    at t.onAllow ((index):29)
    at t.allowCookies (d3a74733.js:1)
```